### PR TITLE
Update VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl

### DIFF
--- a/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
+++ b/vocab/quantitykinds/VOCAB_QUDT-QUANTITY-KINDS-ALL-v2.1.ttl
@@ -1126,7 +1126,6 @@ quantitykind:CelsiusTemperature
   rdfs:isDefinedBy <http://qudt.org/2.1/vocab/quantitykind> ;
   rdfs:label "Celsius temperature"@en ;
   skos:broader quantitykind:ThermodynamicTemperature ;
-  prov:wasDerivedFrom quantitykind:ThermodynamicTemperature ;
 .
 quantitykind:CharacteristicAcousticImpedance
   a qudt:QuantityKind ;


### PR DESCRIPTION
This is the only usage of prov:wasDerivedFrom in any quantity kind instance.  I suspect it was a simple mistake(?)  skos:broader is being used with the same value as :wasDerivedFrom.